### PR TITLE
Disable development error logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,7 @@ Method | Arguments | Return | Description
 `clearCache` | none | none | Replaces the cache with an empty object and creates a new linked list.
 `getSize` | none | number | Returns the number of data objects stored in the cache.
 `extract` | filter[object] | array | Like get, but removes returned data from cache. 
+
+## Environment variables
+
+To log console errors when the cache has missing parameters upon `get()` or `extract()` calls, set the `process.env.CACHE_TREE_LOG_LEVEL` variable in your node environment to 'error'.

--- a/cachetree.js
+++ b/cachetree.js
@@ -64,7 +64,7 @@ export default class CacheTree {
 
       return castArray(datum);
     } else if (has(filter, pathNode) && isArray(filter[pathNode])) {
-      if (process.env.NODE_ENV === 'development') {
+      if (process.env.CACHE_TREE_LOG_LEVEL === 'error') {
         forEach(filter[pathNode], (item) => {
           if (!has(cache, item)) {
             console.error(`missing parameter: ${pathNode}: ${item}`);

--- a/es/cachetree.js
+++ b/es/cachetree.js
@@ -67,7 +67,7 @@ var CacheTree = function () {
 
         return castArray(datum);
       } else if (has(filter, pathNode) && isArray(filter[pathNode])) {
-        if (process.env.NODE_ENV === 'development') {
+        if (process.env.CACHE_TREE_LOG_LEVEL === 'error') {
           forEach(filter[pathNode], function (item) {
             if (!has(cache, item)) {
               console.error('missing parameter: ' + pathNode + ': ' + item);

--- a/lib/cachetree.js
+++ b/lib/cachetree.js
@@ -73,7 +73,7 @@ var CacheTree = function () {
 
         return (0, _lodash.castArray)(datum);
       } else if ((0, _lodash.has)(filter, pathNode) && (0, _lodash.isArray)(filter[pathNode])) {
-        if (process.env.NODE_ENV === 'development') {
+        if (process.env.CACHE_TREE_LOG_LEVEL === 'error') {
           (0, _lodash.forEach)(filter[pathNode], function (item) {
             if (!(0, _lodash.has)(cache, item)) {
               console.error('missing parameter: ' + pathNode + ': ' + item);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache-tree",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A class for storing client-side data for reuse with an LRU algorithm.",
   "keywords": [
     "cache",


### PR DESCRIPTION
After making some changes to the webpack configuration in one of our apps that still uses CacheTree (CoDViz!) we started getting a lot of unwanted error logs to the console.  This PR disables those errors by changing to a custom environment variable instead of using the default development environment variable `process.env.NODE_ENV === 'development'`.